### PR TITLE
[#18] [Chore] Make all the models Parcelable

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/AdditionalDocumentDetails.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/AdditionalDocumentDetails.kt
@@ -1,6 +1,10 @@
 package co.nimblehq.alpine.lib.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class AdditionalDocumentDetails(
     val dateOfIssue: String?,
     val issuingAuthority: String?
-)
+) : Parcelable

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/AdditionalPersonDetails.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/AdditionalPersonDetails.kt
@@ -1,5 +1,9 @@
 package co.nimblehq.alpine.lib.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class AdditionalPersonDetails(
     val custodyInformation: String?,
     val fullDateOfBirth: String?,
@@ -16,4 +20,4 @@ data class AdditionalPersonDetails(
     val tags: List<Int>?,
     val telephone: String?,
     val title: String?
-)
+) : Parcelable

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/Biometrics.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/Biometrics.kt
@@ -1,10 +1,13 @@
 package co.nimblehq.alpine.lib.model
 
 import android.graphics.Bitmap
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class Biometrics(
     val faceImage: Image?,
     val portraitImage: Image?,
     val signatureImage: Image?,
     val fingerprints: List<Bitmap>?
-)
+) : Parcelable

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/Image.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/Image.kt
@@ -1,8 +1,11 @@
 package co.nimblehq.alpine.lib.model
 
 import android.graphics.Bitmap
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class Image(
     val bitmap: Bitmap?,
     val base64: String?
-)
+) : Parcelable

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/MrzInfo.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/MrzInfo.kt
@@ -1,10 +1,14 @@
 package co.nimblehq.alpine.lib.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class MrzInfo(
     val documentNumber: String,
     val dateOfBirth: String,
     val dateOfExpiry: String
-) {
+) : Parcelable {
 
     companion object {
         fun createFrom(

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/PassportInfo.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/PassportInfo.kt
@@ -1,7 +1,10 @@
 package co.nimblehq.alpine.lib.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.security.PublicKey
 
+@Parcelize
 data class PassportInfo(
     val documentType: DocumentType?,
     val personDetails: PersonDetails?,
@@ -9,4 +12,4 @@ data class PassportInfo(
     val additionalPersonDetails: AdditionalPersonDetails?,
     val additionalDocumentDetails: AdditionalDocumentDetails?,
     val documentPublicKey: PublicKey?
-)
+) : Parcelable

--- a/lib/src/main/java/co/nimblehq/alpine/lib/model/PersonDetails.kt
+++ b/lib/src/main/java/co/nimblehq/alpine/lib/model/PersonDetails.kt
@@ -1,5 +1,9 @@
 package co.nimblehq.alpine.lib.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class PersonDetails(
     val name: String?,
     val surname: String?,
@@ -10,4 +14,4 @@ data class PersonDetails(
     val documentNumber: String?,
     val nationality: String?,
     val issuingState: String?
-)
+) : Parcelable


### PR DESCRIPTION
https://github.com/nimblehq/alpine/issues/18

## What happened 👀

To allow the app developers to pass the models around different screens, we need to make them Parcelable.

## Insight 📝

- Added `Parcelize` gradle plugin to `:lib` module to use the `@Parcelize` annotation.

Closes #18 