### PR TITLE
[#31] Publish library to JitPack

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
+    id 'maven-publish'
 }
 
 android {
@@ -44,4 +45,18 @@ dependencies {
             "com.github.mhshams:jnbis:1.1.0",
             "net.sf.scuba:scuba-sc-android:0.0.23"
     )
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                groupId = 'com.github.nimblehq'
+                artifactId = 'alpine'
+                version = '1.0.0'
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #31 

## What happened 👀

Configure Gradle to publish the library on JitPack.

## Insight 📝

- Added required plugins and other configurations.

## Proof Of Work 📹

N/A
